### PR TITLE
Force value to be a string so PostCSS does not append `px`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const lineClamp = plugin(
               overflow: 'hidden',
               display: '-webkit-box',
               '-webkit-box-orient': 'vertical',
-              '-webkit-line-clamp': value,
+              '-webkit-line-clamp': `${value}`,
             },
           }
         }),


### PR DESCRIPTION
This PR addresses this issue: https://github.com/tailwindlabs/tailwindcss-line-clamp/issues/2

If someone chooses to configure the values for lineClamp but uses a number instead of a string, PostCSS will convert the unitless value to a pixel value:

e.g. `tailwind.config.js`:
```js
module.exports = {
  theme: {
    lineClamp: {
      1: 1,
      2: 2,
      3: 3,
    },
  },
};
```

Outputs:
```css
.line-clamp-1 {
  overflow: hidden;
  display: -webkit-box;
  -webkit-box-orient: vertical;
  -webkit-line-clamp: 1px; /* This should be 1 */
}

.line-clamp-2 {
  overflow: hidden;
  display: -webkit-box;
  -webkit-box-orient: vertical;
  -webkit-line-clamp: 2px; /* This should be 2 */
}

.line-clamp-3 {
  overflow: hidden;
  display: -webkit-box;
  -webkit-box-orient: vertical;
  -webkit-line-clamp: 3px; /* This should be 3 */
}
```