### PR TITLE
mark tailwindcss as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "node scripts/build.js"
   },
   "peerDependencies": {
-    "tailwindcss": "^2.0.0"
+    "tailwindcss": ">=2.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "scripts": {
     "prepublishOnly": "node scripts/build.js"
   },
+  "peerDependencies": {
+    "tailwindcss": "^2.0.0"
+  },
   "devDependencies": {
     "autoprefixer": "^10.2.0",
     "clean-css": "^4.2.1",


### PR DESCRIPTION
This plugin uses tailwindcss internally, but marks it only as a dev dependency rather than a peer dependency, causing errors/undefined behavior in monorepos and Yarn PNP. Correctly adding tailwind as a peer dependency allows for correct resolution to occur while still referencing the *user's* tailwind and not an internal version.

Other official plugins have already corrected this: see https://github.com/tailwindlabs/tailwindcss-forms/commit/8a8671b3ec62a7e71ca8477d50e80042ee40f0e6