### PR TITLE
Use built-in `log.warn` function from Tailwind CSS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const semver = require('semver')
 const tailwindPkg = require('tailwindcss/package.json')
 const plugin = require('tailwindcss/plugin')
+const log = require('tailwindcss/lib/util/log').default
 
 const baseStyles = {
   overflow: 'hidden',
@@ -11,13 +12,10 @@ const baseStyles = {
 const lineClamp = plugin(
   function ({ matchUtilities, addUtilities, theme, variants }) {
     if (semver.gte(tailwindPkg.version, '3.3.0')) {
-      console.log(
-        `\u001b[31m${[
-          'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
-          'Remove it from the `plugins` array in your configuration to eliminate this warning.',
-        ].join('\n')}\u001b[0m`
-      )
-
+      log.warn('line-clamp-in-core', [
+        'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
+        'Remove it from the `plugins` array in your configuration to eliminate this warning.',
+      ])
       return
     }
 


### PR DESCRIPTION
This PR improves the warning message to be consistent with the default warnings you get from Tailwind CSS.

The `log.warn` function ensures that, given a key, the warning is only logged once instead of `n` times in case the function is invoked multiple times.
