### PR TITLE
Remove Tailwind CSS v3.3 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Remove Tailwind CSS v3.3 warning ([#28](https://github.com/tailwindlabs/tailwindcss-line-clamp/pull/28))
 
 ## [0.4.3] - 2023-03-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@tailwindcss/line-clamp",
       "version": "0.4.3",
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.8"
-      },
       "devDependencies": {
         "jest": "^27.4.4",
         "postcss": "^8.2.2",
@@ -3240,6 +3237,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3971,6 +3969,7 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4570,7 +4569,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -7097,6 +7097,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -7589,6 +7590,7 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -8037,7 +8039,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,5 @@
     "setupFilesAfterEnv": [
       "<rootDir>/jest/customMatchers.js"
     ]
-  },
-  "dependencies": {
-    "semver": "^7.3.8"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-const semver = require('semver')
-const tailwindPkg = require('tailwindcss/package.json')
 const plugin = require('tailwindcss/plugin')
 
 const baseStyles = {
@@ -10,17 +8,6 @@ const baseStyles = {
 
 const lineClamp = plugin(
   function ({ matchUtilities, addUtilities, theme, variants }) {
-    if (semver.gte(tailwindPkg.version, '3.3.0')) {
-      console.log(
-        `\u001b[31m${[
-          'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
-          'Remove it from the `plugins` array in your configuration to eliminate this warning.',
-        ].join('\n')}\u001b[0m`
-      )
-
-      return
-    }
-
     const values = theme('lineClamp')
 
     matchUtilities(


### PR DESCRIPTION
This PR reverts the changes made in #26, as we've found a way to handle this in an automated way in Tailwind CSS itself:

https://github.com/tailwindlabs/tailwindcss/pull/10919