### PR TITLE
 Update installation instructions for TailwindCSS V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,11 @@ Install the plugin from npm:
 npm install -D @tailwindcss/line-clamp
 ```
 
-Then add the plugin to your `tailwind.config.js` file:
+Then add the plugin to your main `style.css` file:
 
-```js
-// tailwind.config.js
-module.exports = {
-  theme: {
-    // ...
-  },
-  plugins: [
-    require('@tailwindcss/line-clamp'),
-    // ...
-  ],
-}
+```diff
+  @import "tailwindcss";
++ @plugin "@tailwindcss/line-clamp";
 ```
 
 ## Usage


### PR DESCRIPTION
Updates the installation instructions for the plugin for Tailwind V4. Matches the style of the instructions for the already updated docs in [`@tailwindcss/typography`](https://github.com/tailwindlabs/tailwindcss-typography).